### PR TITLE
Break up huge config code block to improve readability

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -237,7 +237,10 @@ module ActiveRecord
   # This applies to all non-transactional callbacks, and to +before_commit+.
   #
   # For transactional +after_+ callbacks (+after_commit+, +after_rollback+, etc), the order
-  # can be set by +config.active_record.run_after_transaction_callbacks_in_order_defined+.
+  # can be set via configuration.
+  #
+  #   config.active_record.run_after_transaction_callbacks_in_order_defined = false
+  #
   # If +true+ (the default from Rails 7.1), callbacks are executed in the order they
   # are defined, just like the example above. If +false+, the order is reversed, so
   # +do_something_else+ is executed before +log_children+.


### PR DESCRIPTION
Before

![Screenshot 2023-01-17 at 10 23 19](https://user-images.githubusercontent.com/277819/212789613-4dfc6993-f47a-4f7d-b3c0-ff4524d427f1.png)

After

![Screenshot 2023-01-17 at 10 20 37](https://user-images.githubusercontent.com/277819/212789621-3fc13498-c2f1-4460-bf25-5305247286bc.png)

---

This is more of a style preference, but I noticed because of the long code block mid paragraph, it increased the surrounding word spacing.